### PR TITLE
Add sitemap generation and robots.txt configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "resend": "^4.6.0",
     "serpapi": "^2.1.0",
     "sharp": "^0.34.2",
+    "sitemap": "^8.0.0",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       sharp:
         specifier: ^0.34.2
         version: 0.34.2
+      sitemap:
+        specifier: ^8.0.0
+        version: 8.0.0
       sonner:
         specifier: ^2.0.5
         version: 2.0.5(react-dom@19.2.0-canary-a00ca6f6-20250611(react@19.2.0-canary-a00ca6f6-20250611))(react@19.2.0-canary-a00ca6f6-20250611)
@@ -2102,6 +2105,9 @@ packages:
   '@types/lodash@4.17.17':
     resolution: {integrity: sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==}
 
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
   '@types/node@20.19.0':
     resolution: {integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==}
 
@@ -2118,6 +2124,9 @@ packages:
 
   '@types/react@19.0.1':
     resolution: {integrity: sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -2389,6 +2398,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4430,6 +4442,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
@@ -4522,6 +4537,11 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sitemap@8.0.0:
+    resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    hasBin: true
 
   slate-history@0.86.0:
     resolution: {integrity: sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==}
@@ -6817,6 +6837,8 @@ snapshots:
 
   '@types/lodash@4.17.17': {}
 
+  '@types/node@17.0.45': {}
+
   '@types/node@20.19.0':
     dependencies:
       undici-types: 6.21.0
@@ -6834,6 +6856,10 @@ snapshots:
   '@types/react@19.0.1':
     dependencies:
       csstype: 3.1.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 20.19.0
 
   '@types/webidl-conversions@7.0.3': {}
 
@@ -7129,6 +7155,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -9345,6 +9373,8 @@ snapshots:
       immutable: 4.3.7
       source-map-js: 1.2.1
 
+  sax@1.4.1: {}
+
   scheduler@0.25.0: {}
 
   scheduler@0.27.0-canary-a00ca6f6-20250611: {}
@@ -9473,6 +9503,13 @@ snapshots:
   simple-wcswidth@1.0.1: {}
 
   sisteransi@1.0.5: {}
+
+  sitemap@8.0.0:
+    dependencies:
+      '@types/node': 17.0.45
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.4.1
 
   slate-history@0.86.0(slate@0.91.4):
     dependencies:

--- a/src/app/(app)/(sitemaps)/sitemaps.xml/route.ts
+++ b/src/app/(app)/(sitemaps)/sitemaps.xml/route.ts
@@ -1,0 +1,56 @@
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import { Readable } from 'stream';
+
+export async function GET() {
+    const SITE_URL =
+        process.env.NEXT_PUBLIC_SERVER_URL ||
+        process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+        'https://example.com';
+    const payload = await getPayload({ config });
+
+    const locales = ['fr', 'en', 'it'];
+    const dateFallback = new Date().toISOString();
+
+    const result = await payload.find({
+        collection: 'pages',
+        draft: false,
+        depth: 0,
+        where: {
+            _status: { equals: 'published' },
+        },
+        limit: 1000,
+    });
+
+    const pages = result.docs || [];
+
+    // We'll build an array of URLs for sitemap including alternates as <xhtml:link>
+    // But since SitemapStream doesn't support alternates automatically,
+    // we must manually generate XML for alternates or use sitemap v7+ with the right options.
+
+    // The sitemap package supports passing 'links' for alternate hreflang,
+    // but they need to be lowercase: 'links' array with { lang, url }
+
+    const links = pages.flatMap((page) =>
+        locales.map((locale) => ({
+            url: page.slug === 'home' ? `/${locale}` : `/${locale}/${page.slug}`,
+            lastmod: page.updatedAt || dateFallback,
+            links: locales.map((alt) => ({
+                lang: alt,
+                url: page.slug === 'home' ? `${SITE_URL}/${alt}` : `${SITE_URL}/${alt}/${page.slug}`,
+            })),
+        })),
+    );
+
+    const stream = new SitemapStream({ hostname: SITE_URL });
+    const xml = await streamToPromise(Readable.from(links).pipe(stream)).then((data) =>
+        data.toString(),
+    );
+
+    return new Response(xml, {
+        headers: {
+            'Content-Type': 'application/xml',
+        },
+    });
+}

--- a/src/app/(app)/robots.ts
+++ b/src/app/(app)/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+            disallow: '/private/',
+        },
+        sitemap: `${process.env.NEXT_PUBLIC_SITE_URL}/sitemap.xml`,
+    };
+}


### PR DESCRIPTION
Implemented dynamic sitemap generation for multiple locales using Payload CMS and the `sitemap` package. Added a robots.txt route with default rules and a link to the generated sitemap. Updated dependencies in `package.json` and modified the lock file to include the necessary packages.