### PR TITLE
Add sitemap generation and robots.txt configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "type": "module",
   "main": "dist/server.js",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
-    "dev": "cross-env NODE_OPTIONS=--no-deprecation && next dev",
+    "generate-sitemap": "tsx src/scripts/generate-sitemap.ts",
+    "build": "cross-env NODE_OPTIONS=--no-deprecation tsx src/scripts/generate-sitemap.ts && next build",
+    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:schema": "payload-graphql generate:schema",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -23,9 +23,7 @@ export const generateMeta = async (args: { doc: Partial<Page> | null }): Promise
 
     const ogImage = getImageURL(doc?.meta?.image);
 
-    const title = doc?.meta?.title
-        ? doc?.meta?.title + ' | Payload Website Template'
-        : 'Payload Website Template';
+    const title = doc?.meta?.title ? doc?.meta?.title : 'Payload Website Template';
 
     return {
         description: doc?.meta?.description,


### PR DESCRIPTION
Implemented dynamic sitemap generation for multiple locales using Payload CMS and the `sitemap` package. Added a robots.txt route with default rules and a link to the generated sitemap. Updated dependencies in `package.json` and modified the lock file to include the necessary packages.