### PR TITLE
Fix alignment issue in Carousel for medium screens

### DIFF
--- a/src/blocks/residence-general/index.tsx
+++ b/src/blocks/residence-general/index.tsx
@@ -169,7 +169,7 @@ export function ResidenceGeneralBlock(props: ResidenceGeneralBlockProps) {
 
                                 {/* Icons Carousel */}
                                 <Carousel className="w-full">
-                                    <CarouselContent className="w-full max-sm:-ml-4 lg:justify-center">
+                                    <CarouselContent className="w-full max-sm:-ml-4 md:justify-center">
                                         {residence.residenceGroup.iconArray.map((icon, i) => (
                                             <CarouselItem
                                                 key={i}


### PR DESCRIPTION
Changed the alignment class from `lg:justify-center` to `md:justify-center` to ensure proper centering of the carousel content on medium-sized screens. This resolves a layout inconsistency for better user experience.